### PR TITLE
adds instructions on building a Docker image of this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ CMD ["nginx", "-g", "daemon off;"]
 3.) Tag the Docker Image using `docker tag 2048 ghcr.io/tunzor/hashi-2048:1.0.0`
 
 4.) Push the Docker Image to [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry) using `docker push ghcr.io/tunzor/hashi-2048:1.0.0`
+
+5.) Run the Docker image locally using `docker run -p 8080:80 ghcr.io/tunzor/hashi-2048:1.0.0`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,34 @@
 # 2048
+
 A HashiCorp reskin of [Gabriele Cirulli's version of 2048](https://github.com/gabrielecirulli/2048).
 
 Playable [here](https://tunzor.ca/hashi-2048)
 
-### Screenshot
+## Screenshot
 ![2048 screenshot](images/screen-cap.jpg)
+
+## Docker Image
+
+A Docker Image of 2048 can be built with the following `Dockerfil`:
+
+```dockerfile
+FROM alpine:latest
+
+MAINTAINER Anthony Russo <github.com/tunzor>
+
+RUN apk --update add nginx
+
+COPY ./2048 /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]  
+```
+
+1.) Create a `Dockerfile` in the directory _above_ the clone of this repository.
+
+2.) Build the Docker Image locally using `docker build . --tag "2048"`
+
+3.) Tag the Docker Image using `docker tag 2048 ghcr.io/tunzor/hashi-2048:1.0.0`
+
+4.) Push the Docker Image to [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry) using `docker push ghcr.io/tunzor/hashi-2048:0.1.0`

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ CMD ["nginx", "-g", "daemon off;"]
 
 3.) Tag the Docker Image using `docker tag 2048 ghcr.io/tunzor/hashi-2048:1.0.0`
 
-4.) Push the Docker Image to [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry) using `docker push ghcr.io/tunzor/hashi-2048:0.1.0`
+4.) Push the Docker Image to [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry) using `docker push ghcr.io/tunzor/hashi-2048:1.0.0`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Playable [here](https://tunzor.ca/hashi-2048)
 
 ## Docker Image
 
-A Docker Image of 2048 can be built with the following `Dockerfil`:
+A Docker Image of 2048 can be built with the following `Dockerfile`:
 
 ```dockerfile
 FROM alpine:latest

--- a/README.md
+++ b/README.md
@@ -12,17 +12,13 @@ Playable [here](https://tunzor.ca/hashi-2048)
 A Docker Image of 2048 can be built with the following `Dockerfile`:
 
 ```dockerfile
-FROM alpine:latest
+FROM nginx:latest
 
-MAINTAINER Anthony Russo <github.com/tunzor>
-
-RUN apk --update add nginx
-
-COPY ./2048 /usr/share/nginx/html
+COPY . /usr/share/nginx/html
 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]  
+CMD ["nginx", "-g", "daemon off;"]
 ```
 
 1.) Create a `Dockerfile` in the directory _above_ the clone of this repository.


### PR DESCRIPTION
Hey @tunzor,

@im2nguyen alerted me to this repository, so I decided to use it in demo for [@ksatirli/kubernetes-ingress-with-consul-and-ngrok](https://github.com/ksatirli/kubernetes-ingress-with-consul-and-ngrok/)

For that, I needed a Dockerized version of the repository, so figured I'd share the instructions